### PR TITLE
fix: compat with non-Windows platform

### DIFF
--- a/jjcrawler/jjcrawler/spiders/config.py
+++ b/jjcrawler/jjcrawler/spiders/config.py
@@ -1,4 +1,7 @@
-default_directory = "..\\novels\\"
+from pathlib import Path
+
+
+default_directory = Path('../novels')
 
 # docx | txt
 # change this to "txt" if you would like to download the chapters in txt format

--- a/jjcrawler/jjcrawler/spiders/doc.py
+++ b/jjcrawler/jjcrawler/spiders/doc.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from docx import Document
 from docx.shared import Pt, Cm, RGBColor
 from docx.enum.text import WD_ALIGN_PARAGRAPH
@@ -17,7 +18,7 @@ def set_doc_style(doc):
     normal_paragraph_format.line_spacing = Pt(14)
 
 
-def create_desc_doc(directory, novel):
+def create_desc_doc(directory: Path, novel):
     print(f"下载 文案 中...")
     description_doc = Document()
     file_name = "文案"
@@ -39,11 +40,11 @@ def create_desc_doc(directory, novel):
     meaning_paragraph = description_doc.add_paragraph(novel["meaning"])
     meaning_paragraph.runs[0].font.color.rgb = RGBColor(0xF9, 0x8C, 0x4D)
 
-    output_path = f"{directory}{file_name}.docx"
+    output_path = directory / f"{file_name}.docx"
     description_doc.save(output_path)
 
 
-def create_chapter_doc(directory, chapter):
+def create_chapter_doc(directory: Path, chapter):
     chapter_doc = Document()
     file_name = get_file_name(chapter)
     print(f"下载 {file_name} 中...")
@@ -68,5 +69,5 @@ def create_chapter_doc(directory, chapter):
                 author_said_paragraph.runs[0].font.color.rgb = RGBColor(
                     0x00, 0x99, 0x00
                 )
-    output_path = f"{directory}{file_name}.docx"
+    output_path = directory / f"{file_name}.docx"
     chapter_doc.save(output_path)

--- a/jjcrawler/jjcrawler/spiders/txt.py
+++ b/jjcrawler/jjcrawler/spiders/txt.py
@@ -1,10 +1,11 @@
+from pathlib import Path
 from .utils import get_file_name, get_heading, format_body
 
 
-def create_desc_txt(directory, novel):
-    print(f"下载 文案 中...")
+def create_desc_txt(directory: Path, novel):
+    print("下载 文案 中...")
     file_name = "文案"
-    output_path = f"{directory}{file_name}.txt"
+    output_path = directory / f"{file_name}.txt"
     description_txt = open(output_path, "w", encoding="utf-8")
 
     for paragraph in novel["desc"]:
@@ -22,11 +23,11 @@ def create_desc_txt(directory, novel):
     description_txt.close()
 
 
-def create_chapter_txt(directory, chapter):
+def create_chapter_txt(directory: Path, chapter):
     file_name = get_file_name(chapter)
     print(f"下载 {file_name} 中...")
 
-    output_path = f"{directory}{file_name}.txt"
+    output_path = directory / f"{file_name}.txt"
     chapter_txt = open(output_path, "w", encoding="utf-8")
 
     heading = get_heading(chapter)

--- a/jjcrawler/jjcrawler/spiders/utils.py
+++ b/jjcrawler/jjcrawler/spiders/utils.py
@@ -1,7 +1,7 @@
 import requests
 import re
-import os
 import logging
+from pathlib import Path
 from rich.table import Table
 from rich.panel import Panel
 from rich import print
@@ -35,12 +35,12 @@ def process_desc(desc_selector_list):
     return desc
 
 
-def get_cover_path(directory, title):
+def get_cover_path(directory: Path, title):
     file_extension = ".jpg"
-    return f"{directory}{title}{file_extension}"
+    return directory / f"{title}{file_extension}"
 
 
-def download_cover(directory, novel):
+def download_cover(directory: Path, novel):
     print(f"下载 封面 中...")
     url = novel["cover_url"]
     if url:
@@ -61,12 +61,10 @@ def get_chapter_id(url: str) -> str:
     return chapter_id
 
 
-def make_directories(novel) -> str:
-    if not os.path.exists(default_directory):
-        os.mkdir(default_directory)
-    directory = f"{default_directory}{novel['id'].rjust(7, '0')}-{novel['title']}\\"
-    if not os.path.exists(directory):
-        os.mkdir(directory)
+def make_directories(novel) -> Path:
+    novel_slug = f"{novel['id'].rjust(7, '0')}-{novel['title']}"
+    directory = default_directory / novel_slug
+    directory.mkdir(parents=True, exist_ok=True)
     return directory
 
 


### PR DESCRIPTION
目前路径是用字符串拼接的，导致爬虫在非 Windows 环境下（如 Linux 和 macOS）运行的时候，会创建出奇怪的文件名。

该 PR 改用 `pathlib.Path` 操作路径，以兼容非 Windows 平台。

已在 Linux 下测试通过。
